### PR TITLE
Backport GHSA-c9cp-9c75-9v8c to 1.4

### DIFF
--- a/oci/spec.go
+++ b/oci/spec.go
@@ -148,10 +148,9 @@ func populateDefaultUnixSpec(ctx context.Context, s *Spec, id string) error {
 				GID: 0,
 			},
 			Capabilities: &specs.LinuxCapabilities{
-				Bounding:    defaultUnixCaps(),
-				Permitted:   defaultUnixCaps(),
-				Inheritable: defaultUnixCaps(),
-				Effective:   defaultUnixCaps(),
+				Bounding:  defaultUnixCaps(),
+				Permitted: defaultUnixCaps(),
+				Effective: defaultUnixCaps(),
 			},
 			Rlimits: []specs.POSIXRlimit{
 				{

--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -770,7 +770,6 @@ func WithCapabilities(caps []string) SpecOpts {
 		s.Process.Capabilities.Bounding = caps
 		s.Process.Capabilities.Effective = caps
 		s.Process.Capabilities.Permitted = caps
-		s.Process.Capabilities.Inheritable = caps
 
 		return nil
 	}
@@ -828,7 +827,6 @@ func WithAddedCapabilities(caps []string) SpecOpts {
 				&s.Process.Capabilities.Bounding,
 				&s.Process.Capabilities.Effective,
 				&s.Process.Capabilities.Permitted,
-				&s.Process.Capabilities.Inheritable,
 			} {
 				if !capsContain(*cl, c) {
 					*cl = append(*cl, c)
@@ -848,7 +846,6 @@ func WithDroppedCapabilities(caps []string) SpecOpts {
 				&s.Process.Capabilities.Bounding,
 				&s.Process.Capabilities.Effective,
 				&s.Process.Capabilities.Permitted,
-				&s.Process.Capabilities.Inheritable,
 			} {
 				removeCap(cl, c)
 			}
@@ -864,6 +861,7 @@ func WithAmbientCapabilities(caps []string) SpecOpts {
 	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
 		setCapabilities(s)
 
+		s.Process.Capabilities.Inheritable = caps
 		s.Process.Capabilities.Ambient = caps
 		return nil
 	}

--- a/oci/spec_opts_test.go
+++ b/oci/spec_opts_test.go
@@ -585,7 +585,6 @@ func TestDropCaps(t *testing.T) {
 		s.Process.Capabilities.Bounding,
 		s.Process.Capabilities.Effective,
 		s.Process.Capabilities.Permitted,
-		s.Process.Capabilities.Inheritable,
 	} {
 		if capsContain(cl, "CAP_CHOWN") {
 			t.Errorf("cap list %d contains dropped cap", i)

--- a/oci/spec_test.go
+++ b/oci/spec_test.go
@@ -44,7 +44,6 @@ func TestGenerateSpec(t *testing.T) {
 		for _, cl := range [][]string{
 			s.Process.Capabilities.Bounding,
 			s.Process.Capabilities.Permitted,
-			s.Process.Capabilities.Inheritable,
 			s.Process.Capabilities.Effective,
 		} {
 			for i := 0; i < len(defaults); i++ {
@@ -192,8 +191,8 @@ func TestWithCapabilities(t *testing.T) {
 	if len(s.Process.Capabilities.Permitted) != 1 || s.Process.Capabilities.Permitted[0] != "CAP_SYS_ADMIN" {
 		t.Error("Unexpected capabilities set")
 	}
-	if len(s.Process.Capabilities.Inheritable) != 1 || s.Process.Capabilities.Inheritable[0] != "CAP_SYS_ADMIN" {
-		t.Error("Unexpected capabilities set")
+	if len(s.Process.Capabilities.Inheritable) != 0 {
+		t.Errorf("Unexpected capabilities set: length is non zero (%d)", len(s.Process.Capabilities.Inheritable))
 	}
 }
 

--- a/vendor/github.com/containerd/cri/pkg/server/container_create_unix.go
+++ b/vendor/github.com/containerd/cri/pkg/server/container_create_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*


### PR DESCRIPTION
[release/1.4] Fix the Inheritable capability defaults.